### PR TITLE
Update WSelector to v0.2.1

### DIFF
--- a/io.github.Cookiiieee.WSelector.json
+++ b/io.github.Cookiiieee.WSelector.json
@@ -182,8 +182,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/Cookiiieee/WSelector.git",
-                    "tag": "v0.2.0",
-                    "commit": "8bdc871e55c170514e0e664d76a6b52c5d2a3a20"
+                    "tag": "v0.2.1",
+                    "commit": "e3dac0c1be0658988cedb83a914b0a2b719d8930"
                 }
             ],
             "build-commands": [


### PR DESCRIPTION
## Changes in v0.2.1

### Bug Fixes
- Fixed Python 3.12 crash during application shutdown
- Improved resource cleanup on exit
- Enhanced stability of the shutdown sequence

### Updates
- Updated application version to v0.2.1
- Updated repository tag to v0.2.1
- Updated commit hash to latest stable version

### Testing
- Verified clean shutdown on Python 3.12
- Confirmed all core functionality works as expected
- Tested on both X11 and Wayland

### Notes
- This update addresses stability issues reported by users
- No breaking changes introduced